### PR TITLE
Replace get_pdb with get_file in readme (v2 API change)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ let symbol_cache = SymbolCache::new(symbol_path, false);
 // Download and cache a PDB file.
 let relative_path: PathBuf =
     ["dcomp.pdb", "648B8DD0780A4E22FA7FA89B84633C231", "dcomp.pdb"].iter().collect();
-let file_contents = symbol_cache.get_pdb(&relative_path).await?;
+let file_contents = symbol_cache.get_file(&relative_path).await?;
 
 // Use the PDB file contents.
 use_pdb_bytes(&file_contents[..]);


### PR DESCRIPTION
The example in the readme was out of date. I just replaced it with what's in the lib.rs doc comment